### PR TITLE
Update news.gsp

### DIFF
--- a/netbeans.apache.org/src/content/templates/news.gsp
+++ b/netbeans.apache.org/src/content/templates/news.gsp
@@ -22,7 +22,7 @@
 <section class="hero news alternate" style='margin-bottom: 2em'>
     <div class='grid-container'>
         <div class='cell'>
-            <div class="annotation">Just released!</div>
+            <div class="annotation">Take it for a spin!</div>
             <h1>Apache NetBeans 9.0 Beta</h1>
             <p><a class="button success" href="/download/nb90/nb90-beta.html">Read more</a></p>
         </div>


### PR DESCRIPTION
'Just released' can only remain 'just' for so long, better to encourage users to try it than to announce it as just released.